### PR TITLE
Add zip_safe=False to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     author_email='nakahara.kunihiko@gmail.com',
     url='https://github.com/gcaprio/django-bootstrap3-datetimepicker.git',
     license='Apache License 2.0',
+    zip_safe=False,
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
So that people installing this package through `setup.py` won't have it installed as an `egg` archive which makes `collectstatic` harder.
